### PR TITLE
Add sample pooling detection on convolutional layers

### DIFF
--- a/lightspeeur/models/model_converter.py
+++ b/lightspeeur/models/model_converter.py
@@ -403,6 +403,11 @@ class ModelConverter:
                         layer_info['upsample_enable'] = True
                     one_coefficients.append(1 if layer.kernel_size == (1, 1) else 0)
                     conv_included = True
+
+                    # sampling pooling with strides == 2 convolutional layers
+                    if layer.strides[0] == 2:
+                        sampling_poolings += 1
+                        layer_info['pooling'] = True
                     continue
                 if is_pooling(layer):
                     if isinstance(layer, TopLeftPooling2D):


### PR DESCRIPTION
## Issue

The current implementation of automatic model architecture generation does not recognize strides=2 convolutional
 layers as pooling layers.

## Solution

Add sample pooling detection on convolutional layers