### PR TITLE
Provides custom_objects dictionary for model designers

### DIFF
--- a/lightspeeur/layers/__init__.py
+++ b/lightspeeur/layers/__init__.py
@@ -18,3 +18,13 @@ from lightspeeur.layers.quantization import QuantizableLayer, quantize_image
 
 # Constraints
 from lightspeeur.layers.constraints import ClippingBiasConstraint
+
+
+custom_objects = {
+    'ReLU': ReLU,
+    'Conv2D': Conv2D,
+    'Conv2DTranspose': Conv2DTranspose,
+    'DepthwiseConv2D': DepthwiseConv2D,
+    'MaxPooling2D': MaxPooling2D,
+    'TopLeftPooling2D': TopLeftPooling2D
+}


### PR DESCRIPTION
To reduce issues happening when load lightspeeur models, decided to add `custom_objects` variable in `lightspeeur.layers` package.